### PR TITLE
Fix obsolete comment in csv_converter_service.py

### DIFF
--- a/service/csv_converter_service.py
+++ b/service/csv_converter_service.py
@@ -5,7 +5,7 @@ import csv
 from typing import Any, Dict, List, Optional
 
 # ---------------------------
-# Config (matches your plan)
+# Config
 # ---------------------------
 REQUEST_FILE = "csv_request.json"
 DONE_FILE = "csv_done.json"


### PR DESCRIPTION
Fixes #5

Removes the obsolete "(matches your plan)" text from the config section comment on line 8 of `service/csv_converter_service.py`.